### PR TITLE
Parallelize device connection

### DIFF
--- a/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
+++ b/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
@@ -54,6 +54,9 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
             Exception? lastException = null;
             while (Stopwatch.GetElapsedTime(startTime) < MaxWaitGetClientOperations && !cancellationToken.IsCancellationRequested)
             {
+                using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                // reasonably short timeout for individual connection attempts to allow for retries if the device is still coming online
+                attemptCts.CancelAfter(TimeSpan.FromSeconds(1.5));
                 try
                 {
                     connection = await AdbConnection.ConnectTcpAsync(
@@ -63,6 +66,11 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
                         options: null,
                         cancellationToken);
                     break;
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    lastException ??= new TimeoutException("Connect attempt exceeded per-attempt timeout");
+                    // fall through to retry within budget
                 }
                 catch (Exception e) when (e is not OperationCanceledException)
                 {

--- a/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
+++ b/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
@@ -62,12 +62,12 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
                     connection = await AdbConnection.ConnectTcpAsync(
                         adbTvClientKey.IpAddress,
                         adbTvClientKey.Port,
-                        [await GetOrCreateAuthKey(cancellationToken)],
+                        [await GetOrCreateAuthKey(attemptCts.Token)],
                         options: null,
-                        cancellationToken);
+                        attemptCts.Token);
                     break;
                 }
-                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (!attemptCts.Token.IsCancellationRequested)
                 {
                     lastException ??= new TimeoutException("Connect attempt exceeded per-attempt timeout");
                     // fall through to retry within budget

--- a/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
+++ b/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
@@ -49,6 +49,8 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
     {
         try
         {
+            var authKey = await GetOrCreateAuthKey(cancellationToken);
+
             var startTime = Stopwatch.GetTimestamp();
             AdbConnection? connection = null;
             Exception? lastException = null;
@@ -62,7 +64,7 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
                     connection = await AdbConnection.ConnectTcpAsync(
                         adbTvClientKey.IpAddress,
                         adbTvClientKey.Port,
-                        [await GetOrCreateAuthKey(attemptCts.Token)],
+                        [authKey],
                         options: null,
                         attemptCts.Token);
                     break;

--- a/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
+++ b/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
@@ -168,7 +168,6 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
             catch (Exception e)
             {
                 _logger.FailedToRemoveClient(e, adbTvClientKey);
-                throw;
             }
         }
     }

--- a/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
+++ b/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
@@ -67,7 +67,7 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
                         attemptCts.Token);
                     break;
                 }
-                catch (OperationCanceledException) when (!attemptCts.Token.IsCancellationRequested)
+                catch (OperationCanceledException) when (attemptCts.Token.IsCancellationRequested)
                 {
                     lastException ??= new TimeoutException("Connect attempt exceeded per-attempt timeout");
                     // fall through to retry within budget
@@ -225,7 +225,8 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
 
                 await using var adbKeyStream = new FileStream(privateKeyPath, fileStreamOptions);
                 await using var streamWriter = new StreamWriter(adbKeyStream);
-                await streamWriter.WriteAsync(key.ExportPrivateKeyPem().AsMemory(), cancellationToken);
+                // always allow to persist the key
+                await streamWriter.WriteAsync(key.ExportPrivateKeyPem().AsMemory(), CancellationToken.None);
             }
 
             _cachedAuthKey = key;

--- a/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
+++ b/src/UnfoldedCircle.AdbTv/AdbTv/AdbTvClientFactory.cs
@@ -67,7 +67,7 @@ public class AdbTvClientFactory(ILogger<AdbTvClientFactory> logger)
                         attemptCts.Token);
                     break;
                 }
-                catch (OperationCanceledException) when (attemptCts.Token.IsCancellationRequested)
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
                 {
                     lastException ??= new TimeoutException("Connect attempt exceeded per-attempt timeout");
                     // fall through to retry within budget

--- a/src/UnfoldedCircle.AdbTv/Logging/IntegrationLogger.cs
+++ b/src/UnfoldedCircle.AdbTv/Logging/IntegrationLogger.cs
@@ -79,7 +79,7 @@ internal static partial class IntegrationLogger
     private static readonly Action<ILogger, string, string, Exception> FailureDuringEventAction = LoggerMessage.Define<string, string>(
         LogLevel.Error,
         new EventId(16, nameof(FailureDuringEvent)),
-        "{WSId} Failure during event for {Key}.");
+        "[{WSId}] Failure during event for {Key}.");
 
     public static void FailureDuringEvent(this ILogger logger, Exception exception, string wsId, string key) =>
         FailureDuringEventAction(logger, wsId, key, exception);
@@ -143,4 +143,12 @@ internal static partial class IntegrationLogger
     [LoggerMessage(EventId = 31, EventName = nameof(FailedToAcquireSemaphoreForPopulateApps), Level = LogLevel.Warning,
         Message = "[{WSId}] Failed to acquire semaphore for populating apps for entity ID '{EntityId}' within timeout.")]
     public static partial void FailedToAcquireSemaphoreForPopulateApps(this ILogger logger, string wsId, string entityId);
+
+    private static readonly Action<ILogger, string, string, Exception> LogFailureDuringSubscribeEventsAction = LoggerMessage.Define<string, string>(
+        LogLevel.Warning,
+        new EventId(32, nameof(LogFailureDuringSubscribeEventsAction)),
+        "[{WSId}] Failure during subscribe events for entity ID '{EntityId}'.");
+
+    public static void LogFailureDuringSubscribeEvents(this ILogger logger, Exception exception, string wsId, string entityId) =>
+        FailureDuringEventAction(logger, wsId, entityId, exception);
 }

--- a/src/UnfoldedCircle.AdbTv/Logging/IntegrationLogger.cs
+++ b/src/UnfoldedCircle.AdbTv/Logging/IntegrationLogger.cs
@@ -146,9 +146,9 @@ internal static partial class IntegrationLogger
 
     private static readonly Action<ILogger, string, string, Exception> LogFailureDuringSubscribeEventsAction = LoggerMessage.Define<string, string>(
         LogLevel.Warning,
-        new EventId(32, nameof(LogFailureDuringSubscribeEventsAction)),
+        new EventId(32, nameof(LogFailureDuringSubscribeEvents)),
         "[{WSId}] Failure during subscribe events for entity ID '{EntityId}'.");
 
     public static void LogFailureDuringSubscribeEvents(this ILogger logger, Exception exception, string wsId, string entityId) =>
-        FailureDuringEventAction(logger, wsId, entityId, exception);
+        LogFailureDuringSubscribeEventsAction(logger, wsId, entityId, exception);
 }

--- a/src/UnfoldedCircle.AdbTv/WebSocket/AdbWebSocketHandler.cs
+++ b/src/UnfoldedCircle.AdbTv/WebSocket/AdbWebSocketHandler.cs
@@ -469,15 +469,19 @@ internal sealed partial class AdbWebSocketHandler(
         if (payload.MsgData?.EntityIds is not { Length: > 0 })
             return;
 
-        foreach (string msgDataEntityId in payload.MsgData.EntityIds)
+        var alternateLookup = _entityIdAppsMap.GetAlternateLookup<ReadOnlySpan<char>>();
+        await Parallel.ForEachAsync(payload.MsgData.EntityIds, new ParallelOptions
+        {
+            CancellationToken = commandCancellationToken,
+            MaxDegreeOfParallelism = Math.Max(Environment.ProcessorCount, 4)
+        }, async (msgDataEntityId, token) =>
         {
             cancellationTokenWrapper.AddSubscribedEntity(msgDataEntityId);
             var entityType = msgDataEntityId.AsSpan().GetEntityTypeFromIdentifier();
             if (entityType is EntityType.MediaPlayer or EntityType.Select)
-                await PopulateApps(wsId, msgDataEntityId, commandCancellationToken);
+                await PopulateApps(wsId, msgDataEntityId, token);
 
             var baseIdentifier = msgDataEntityId.AsSpan().GetBaseIdentifier();
-            var alternateLookup = _entityIdAppsMap.GetAlternateLookup<ReadOnlySpan<char>>();
             if (!alternateLookup.TryGetValue(baseIdentifier, out var apps))
                 apps = [];
 
@@ -486,15 +490,15 @@ internal sealed partial class AdbWebSocketHandler(
                 string[] sources = [.. apps, AdbTvRemoteCommands.InputHdmi1, AdbTvRemoteCommands.InputHdmi2, AdbTvRemoteCommands.InputHdmi3, AdbTvRemoteCommands.InputHdmi4];
                 await SendMessageAsync(socket,
                     ResponsePayloadHelpers.CreateMediaPlayerStateChangedResponsePayload(new MediaPlayerStateChangedEventMessageDataAttributes { SourceList = sources },
-                        msgDataEntityId), wsId, commandCancellationToken);
+                        msgDataEntityId), wsId, token);
             }
             else if (entityType == EntityType.Select)
             {
                 await SendMessageAsync(socket,
                     ResponsePayloadHelpers.CreateSelectStateChangedPayload(new SelectStateChangedEventMessageDataAttributes { Options = apps.ToArray() }, msgDataEntityId, AdbTvServerConstants.AppListSelectSuffix),
-                    wsId, commandCancellationToken);
+                    wsId, token);
             }
-        }
+        });
     }
 
     protected override async ValueTask OnUnsubscribeEventsAsync(UnsubscribeEventsMsg payload, string wsId, CancellationTokenWrapper cancellationTokenWrapper)

--- a/src/UnfoldedCircle.AdbTv/WebSocket/AdbWebSocketHandler.cs
+++ b/src/UnfoldedCircle.AdbTv/WebSocket/AdbWebSocketHandler.cs
@@ -476,27 +476,37 @@ internal sealed partial class AdbWebSocketHandler(
             MaxDegreeOfParallelism = Math.Max(Environment.ProcessorCount, 4)
         }, async (msgDataEntityId, token) =>
         {
-            cancellationTokenWrapper.AddSubscribedEntity(msgDataEntityId);
-            var entityType = msgDataEntityId.AsSpan().GetEntityTypeFromIdentifier();
-            if (entityType is EntityType.MediaPlayer or EntityType.Select)
-                await PopulateApps(wsId, msgDataEntityId, token);
-
-            var baseIdentifier = msgDataEntityId.AsSpan().GetBaseIdentifier();
-            if (!alternateLookup.TryGetValue(baseIdentifier, out var apps))
-                apps = [];
-
-            if (entityType == EntityType.MediaPlayer)
+            try
             {
-                string[] sources = [.. apps, AdbTvRemoteCommands.InputHdmi1, AdbTvRemoteCommands.InputHdmi2, AdbTvRemoteCommands.InputHdmi3, AdbTvRemoteCommands.InputHdmi4];
-                await SendMessageAsync(socket,
-                    ResponsePayloadHelpers.CreateMediaPlayerStateChangedResponsePayload(new MediaPlayerStateChangedEventMessageDataAttributes { SourceList = sources },
-                        msgDataEntityId), wsId, token);
+                cancellationTokenWrapper.AddSubscribedEntity(msgDataEntityId);
+                var entityType = msgDataEntityId.AsSpan().GetEntityTypeFromIdentifier();
+                if (entityType is EntityType.MediaPlayer or EntityType.Select)
+                    await PopulateApps(wsId, msgDataEntityId, token);
+
+                var baseIdentifier = msgDataEntityId.AsSpan().GetBaseIdentifier();
+                if (!alternateLookup.TryGetValue(baseIdentifier, out var apps))
+                    apps = [];
+
+                if (entityType == EntityType.MediaPlayer)
+                {
+                    string[] sources = [.. apps, AdbTvRemoteCommands.InputHdmi1, AdbTvRemoteCommands.InputHdmi2, AdbTvRemoteCommands.InputHdmi3, AdbTvRemoteCommands.InputHdmi4];
+                    await SendMessageAsync(socket,
+                        ResponsePayloadHelpers.CreateMediaPlayerStateChangedResponsePayload(new MediaPlayerStateChangedEventMessageDataAttributes { SourceList = sources },
+                            msgDataEntityId), wsId, token);
+                }
+                else if (entityType == EntityType.Select)
+                {
+                    await SendMessageAsync(socket,
+                        ResponsePayloadHelpers.CreateSelectStateChangedPayload(new SelectStateChangedEventMessageDataAttributes { Options = apps.ToArray() }, msgDataEntityId, AdbTvServerConstants.AppListSelectSuffix),
+                        wsId, token);
+                }
             }
-            else if (entityType == EntityType.Select)
+            catch (Exception e)
             {
-                await SendMessageAsync(socket,
-                    ResponsePayloadHelpers.CreateSelectStateChangedPayload(new SelectStateChangedEventMessageDataAttributes { Options = apps.ToArray() }, msgDataEntityId, AdbTvServerConstants.AppListSelectSuffix),
-                    wsId, token);
+                // This is expected from control flow, no need to spam logs
+                if (e is OperationCanceledException)
+                    return;
+                _logger.LogFailureDuringSubscribeEvents(e, wsId, msgDataEntityId);
             }
         });
     }


### PR DESCRIPTION
Check devices in parallel when receiving a subscribe entity event so that one offline device doesn't cause skipping of online devices due to cancellation.